### PR TITLE
Use mojo.UI.splitText

### DIFF
--- a/Underline Strikethrough.roboFontExt/lib/Underline StrikeThrough.py
+++ b/Underline Strikethrough.roboFontExt/lib/Underline StrikeThrough.py
@@ -4,7 +4,6 @@ import merz
 from mojo.subscriber import Subscriber, registerRoboFontSubscriber
 from mojo.UI import getDefault, CurrentFontWindow, splitText
 from mojo.extensions import getExtensionDefault, setExtensionDefault
-from lib.tools.unicodeTools import GN2UV
 from fontTools.misc.roundTools import otRound
 
 
@@ -520,7 +519,6 @@ class UnderlineStrikethrough(Subscriber, ezui.WindowController):
                         position=(cursor, baseline),
                         fillColor=self.localFGColor,
                     )
-                    # gName = getKey(ord(char), GN2UV)
                     glyph = viewFont[gName]
                     glyphPath = glyph.getRepresentation("merz.CGPath")
 

--- a/Underline Strikethrough.roboFontExt/lib/Underline StrikeThrough.py
+++ b/Underline Strikethrough.roboFontExt/lib/Underline StrikeThrough.py
@@ -2,7 +2,7 @@ from AppKit import NSApp, NSAppearance, NSAppearanceNameDarkAqua
 import ezui
 import merz
 from mojo.subscriber import Subscriber, registerRoboFontSubscriber
-from mojo.UI import getDefault, CurrentFontWindow
+from mojo.UI import getDefault, CurrentFontWindow, splitText
 from mojo.extensions import getExtensionDefault, setExtensionDefault
 from lib.tools.unicodeTools import GN2UV
 from fontTools.misc.roundTools import otRound
@@ -508,12 +508,19 @@ class UnderlineStrikethrough(Subscriber, ezui.WindowController):
                     self.localStrokeColor = r, g, b, 0.25
 
                 cursor = margin
-                for char in self.testString:
+                
+                charSet = viewFont.asDefcon().unicodeData
+                parsedText = splitText(self.testString, charSet, viewFont.groups)
+                
+                for gName in parsedText:
+                    if gName not in viewFont.keys():
+                        continue
+                    
                     glyphLayer = self.container.appendPathSublayer(
                         position=(cursor, baseline),
                         fillColor=self.localFGColor,
                     )
-                    gName = getKey(ord(char), GN2UV)
+                    # gName = getKey(ord(char), GN2UV)
                     glyph = viewFont[gName]
                     glyphPath = glyph.getRepresentation("merz.CGPath")
 


### PR DESCRIPTION
Fixes #21 and #17 

Replaces a `GN2UV` lookup with the `mojo.UI.splitText` method to better match the experience users are used to in SpaceCenter. Allows for unicode glyphs and /s/l/a/s/h/e/d text, and if the glyph is still not found it'll just ignore it in the merzView instead of trying to display it and getting an error.